### PR TITLE
DEV: Remove use of Ember jquery-integration

### DIFF
--- a/assets/javascripts/discourse/initializers/extend-for-moderator-attention.js
+++ b/assets/javascripts/discourse/initializers/extend-for-moderator-attention.js
@@ -82,7 +82,7 @@ export default {
           this.rerender();
         } else {
           // ninja in url so it does not flash on rerender
-          const first = this.$(".unreviewed")[0];
+          const first = this.element.querySelector(".unreviewed");
           if (first) {
             first.href = this.get("topic.url") + "/" + unreviewed[0];
           }


### PR DESCRIPTION
This has been deprecated for some time, and Discourse will be removing the integration imminently. JQuery itself is still available, so we can replicate the old behaviour using the jquery global and a selector scoped to the component's element.